### PR TITLE
Initialize report path and module_report

### DIFF
--- a/arch/linux/Makefile.am
+++ b/arch/linux/Makefile.am
@@ -1,2 +1,2 @@
-SUBDIRS=daemon net service  #modules
+SUBDIRS=daemon net service 
 

--- a/configure.ac
+++ b/configure.ac
@@ -13,10 +13,6 @@ AC_ARG_ENABLE([fanotify],
 # configuration header
 AM_CONFIG_HEADER(armadito-config-autoconf.h)
 
-# define builtin modules
-AC_DEFINE([HAVE_ON_DEMAND_MODULE],[1],[Define to compile builtin module on-demand])
-dnl AC_DEFINE([HAVE_QUARANTINE_MODULE],[1],[Define to compile builtin module quarantine])
-
 # This is needed when the first PKG_CHECK_MODULES call is inside a conditional (not the case here, but who knows)
 PKG_PROG_PKG_CONFIG
 
@@ -139,6 +135,13 @@ else
 	unset SAVE_CFLAGS
 fi
 AM_CONDITIONAL([COND_FANOTIFY], [test "$enable_fanotify" = "yes" -a "$HAVE_FANOTIFY_INIT" = "yes"])
+if test "$enable_fanotify" = "yes" -a "$HAVE_FANOTIFY_INIT" = "yes"; then
+   AC_DEFINE([HAVE_LINUX_ON_ACCESS_MODULE],[1],[Defined if builtin module on-access is compiled])
+fi
+
+# define builtin modules
+AC_DEFINE([HAVE_ON_DEMAND_MODULE],[1],[Define to compile builtin module on-demand])
+dnl AC_DEFINE([HAVE_QUARANTINE_MODULE],[1],[Define to compile builtin module quarantine])
 
 # check for jansson library (JSON)
 PKG_CHECK_MODULES(LIBJANSSON, jansson, [HAVE_LIBJANSSON=yes], [HAVE_LIBJANSSON=no])

--- a/libcore/Makefile.am
+++ b/libcore/Makefile.am
@@ -27,6 +27,28 @@ scanctx.c \
 status.c \
 status_p.h 
 
+if COND_FANOTIFY
+libcore_a_SOURCES += \
+arch/linux/builtin-modules/on-access/famonitor.c \
+arch/linux/builtin-modules/on-access/famonitor.h \
+arch/linux/builtin-modules/on-access/imonitor.c \
+arch/linux/builtin-modules/on-access/imonitor.h \
+arch/linux/builtin-modules/on-access/onaccessmod.c \
+arch/linux/builtin-modules/on-access/onaccessmod.h \
+arch/linux/builtin-modules/on-access/modname.h \
+arch/linux/builtin-modules/on-access/monitor.c \
+arch/linux/builtin-modules/on-access/monitor.h \
+arch/linux/builtin-modules/on-access/mount.c \
+arch/linux/builtin-modules/on-access/mount.h \
+arch/linux/builtin-modules/on-access/response.c \
+arch/linux/builtin-modules/on-access/response.h \
+arch/linux/builtin-modules/on-access/queue.c \
+arch/linux/builtin-modules/on-access/queue.h \
+arch/linux/builtin-modules/on-access/stamp.h \
+arch/linux/builtin-modules/on-access/watchdog.c \
+arch/linux/builtin-modules/on-access/watchdog.h
+endif
+
 libcore_a_CFLAGS=-I$(top_srcdir) -I$(top_srcdir)/libmodule/include -I$(top_srcdir)/libcore/include -I$(top_srcdir)/libcore/arch/linux
 #libcore_a_LIBADD= 
 

--- a/libcore/arch/linux/builtin-modules/on-access/famonitor.c
+++ b/libcore/arch/linux/builtin-modules/on-access/famonitor.c
@@ -156,6 +156,7 @@ static void fanotify_perm_event_process(struct fanotify_monitor *f, struct fanot
 {
 	struct a6o_scan_context *file_context;
 	enum a6o_scan_context_status context_status;
+	struct a6o_report report;
 	struct stat buf;
 
 	/* the 2 following tests could be removed: */
@@ -177,7 +178,7 @@ static void fanotify_perm_event_process(struct fanotify_monitor *f, struct fanot
 	}
 
 	file_context = malloc(sizeof(struct a6o_scan_context));
-	context_status = a6o_scan_context_get(file_context, event->fd, path, f->scan_conf);
+	context_status = a6o_scan_context_get(file_context, event->fd, path, f->scan_conf, &report);
 
 	if (context_status) {   /* means file must not be scanned */
 		if (watchdog_remove(f->watchdog, event->fd, NULL))

--- a/libcore/arch/linux/builtin-modules/on-access/imonitor.c
+++ b/libcore/arch/linux/builtin-modules/on-access/imonitor.c
@@ -19,12 +19,12 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 
 ***/
 
-#include <libarmadito.h>
+#include <libarmadito/armadito.h>
 #include <armadito-config.h>
 
 #include "imonitor.h"
 #include "monitor.h"
-#include "onaccessmod.h"
+#include "modname.h"
 
 #include <assert.h>
 #include <errno.h>

--- a/libcore/arch/linux/builtin-modules/on-access/modname.h
+++ b/libcore/arch/linux/builtin-modules/on-access/modname.h
@@ -19,23 +19,11 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 
 ***/
 
-#ifndef _FAMONITOR_H_
-#define _FAMONITOR_H_
+#ifndef LIBCORE_MODNAME_H
+#define LIBCORE_MODNAME_H
 
-#include <libarmadito/armadito.h>
+#define MODULE_NAME "on-access-linux"
 
-struct fanotify_monitor;
-
-struct fanotify_monitor *fanotify_monitor_new(struct access_monitor *m, struct armadito *u);
-
-int fanotify_monitor_start(struct fanotify_monitor *f);
-
-int fanotify_monitor_mark_directory(struct fanotify_monitor *f, const char *path, int enable_permission);
-
-int fanotify_monitor_unmark_directory(struct fanotify_monitor *f, const char *path, int enable_permission);
-
-int fanotify_monitor_mark_mount(struct fanotify_monitor *f, const char *path, int enable_permission);
-
-int fanotify_monitor_unmark_mount(struct fanotify_monitor *f, const char *path, int enable_permission);
+#define MODULE_LOG_NAME "on-access for linux"
 
 #endif

--- a/libcore/arch/linux/builtin-modules/on-access/monitor.c
+++ b/libcore/arch/linux/builtin-modules/on-access/monitor.c
@@ -26,14 +26,16 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 
 #define _GNU_SOURCE
 
-#include <libarmadito.h>
+#include <libarmadito/armadito.h>
 #include "armadito-config.h"
+
+#include "core/ondemand.h"
 
 #include "monitor.h"
 #include "famonitor.h"
 #include "imonitor.h"
 #include "mount.h"
-#include "onaccessmod.h"
+#include "modname.h"
 
 #include <assert.h>
 #include <dirent.h>
@@ -407,7 +409,7 @@ static gpointer scan_media_thread_fun(gpointer data)
 
 	a6o_log(A6O_LOG_MODULE, A6O_LOG_LEVEL_INFO, MODULE_LOG_NAME ": " "starting scan of removable media mounted on %s", mount_data->path);
 
-	on_demand = a6o_on_demand_new(mount_data->monitor->ar, -1, mount_data->path, A6O_SCAN_THREADED | A6O_SCAN_RECURSE);
+	on_demand = a6o_on_demand_new(mount_data->monitor->ar, mount_data->path, A6O_SCAN_THREADED | A6O_SCAN_RECURSE, 0);
 	a6o_on_demand_run(on_demand);
 
 	a6o_on_demand_free(on_demand);

--- a/libcore/arch/linux/builtin-modules/on-access/mount.c
+++ b/libcore/arch/linux/builtin-modules/on-access/mount.c
@@ -19,12 +19,12 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 
 ***/
 
-#include <libarmadito.h>
+#include <libarmadito/armadito.h>
 
 #include "armadito-config.h"
 
 #include "mount.h"
-#include "onaccessmod.h"
+#include "modname.h"
 
 #include <gio/gio.h>
 #include <stdio.h>

--- a/libcore/arch/linux/builtin-modules/on-access/onaccessmod.c
+++ b/libcore/arch/linux/builtin-modules/on-access/onaccessmod.c
@@ -19,10 +19,13 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 
 ***/
 
-#include <libarmadito.h>
+#include <libarmadito/armadito.h>
+
+#include "core/scanconf.h"
 
 #include "monitor.h"
 #include "onaccessmod.h"
+#include "modname.h"
 
 #include <glib.h>
 #include <stdlib.h>
@@ -212,7 +215,7 @@ struct a6o_conf_entry mod_oal_conf_table[] = {
 	{ NULL, 0, NULL},
 };
 
-struct a6o_module module = {
+struct a6o_module on_access_linux_module = {
 	.init_fun = mod_oal_init,
 	.conf_table = mod_oal_conf_table,
 	.post_init_fun = mod_oal_post_init,

--- a/libcore/arch/linux/builtin-modules/on-access/onaccessmod.h
+++ b/libcore/arch/linux/builtin-modules/on-access/onaccessmod.h
@@ -19,6 +19,11 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 
 ***/
 
-#define MODULE_NAME "on-access-linux"
-/* #define MODULE_LOG_NAME "OAL" */
-#define MODULE_LOG_NAME "on-access for linux"
+#ifndef LIBCORE_ONACCESSMOD_H
+#define LIBCORE_ONACCESSMOD_H
+
+#include <libarmadito/armadito.h>
+
+extern struct a6o_module on_access_linux_module;
+
+#endif

--- a/libcore/arch/linux/builtin-modules/on-access/response.c
+++ b/libcore/arch/linux/builtin-modules/on-access/response.c
@@ -19,11 +19,11 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 
 ***/
 
-#include <libarmadito.h>
+#include <libarmadito/armadito.h>
 #include <armadito-config.h>
 
 #include "response.h"
-#include "onaccessmod.h"
+#include "modname.h"
 
 #include <errno.h>
 #include <linux/fanotify.h>

--- a/libcore/arch/linux/builtin-modules/on-access/watchdog.c
+++ b/libcore/arch/linux/builtin-modules/on-access/watchdog.c
@@ -19,13 +19,13 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 
 ***/
 
-#include <libarmadito.h>
+#include <libarmadito/armadito.h>
 #include "armadito-config.h"
 
 #include "queue.h"
 #include "stamp.h"
 #include "response.h"
-#include "onaccessmod.h"
+#include "modname.h"
 
 #include <glib.h>
 #include <linux/fanotify.h>

--- a/libcore/arch/linux/builtin-modules/on-demand/ondemandmod.h
+++ b/libcore/arch/linux/builtin-modules/on-demand/ondemandmod.h
@@ -19,8 +19,8 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 
 ***/
 
-#ifndef _LIBARMADITO_ONDEMANDMOD_H_
-#define _LIBARMADITO_ONDEMANDMOD_H_
+#ifndef LIBCORE_ONDEMANDMOD_H
+#define LIBCORE_ONDEMANDMOD_H
 
 #include <libarmadito/armadito.h>
 

--- a/libcore/armadito.c
+++ b/libcore/armadito.c
@@ -32,6 +32,9 @@ along with Armadito core.  If not, see <http://www.gnu.org/licenses/>.
 #ifdef HAVE_ON_DEMAND_MODULE
 #include "builtin-modules/on-demand/ondemandmod.h"
 #endif
+#ifdef HAVE_LINUX_ON_ACCESS_MODULE
+#include "builtin-modules/on-access/onaccessmod.h"
+#endif
 #ifdef HAVE_QUARANTINE_MODULE
 #include "builtin-modules/quarantine/quarantine.h"
 #endif
@@ -68,6 +71,9 @@ static void a6o_add_builtin_modules(struct armadito *u)
 {
 #ifdef HAVE_ON_DEMAND_MODULE
 	module_manager_add(u->module_manager, &on_demand_module);
+#endif
+#ifdef HAVE_LINUX_ON_ACCESS_MODULE
+	module_manager_add(u->module_manager, &on_access_linux_module);
 #endif
 #ifdef HAVE_ON_ACCESS_WINDOWS_MODULE
 	module_manager_add(u->module_manager, &on_access_win_module);

--- a/libcore/include/core/scanctx.h
+++ b/libcore/include/core/scanctx.h
@@ -44,7 +44,7 @@ struct a6o_scan_context {
 	struct a6o_module **applicable_modules;
 };
 
-enum a6o_scan_context_status a6o_scan_context_get(struct a6o_scan_context *ctx, int fd, const char *path, struct a6o_scan_conf *conf);
+enum a6o_scan_context_status a6o_scan_context_get(struct a6o_scan_context *ctx, int fd, const char *path, struct a6o_scan_conf *conf, struct a6o_report *report);
 
 enum a6o_file_status a6o_scan_context_scan(struct a6o_scan_context *ctx, struct a6o_report *report);
 

--- a/libcore/ondemand.c
+++ b/libcore/ondemand.c
@@ -282,6 +282,9 @@ static void scan_file(struct a6o_on_demand *on_demand, const char *path)
 	enum a6o_scan_context_status context_status;
 	struct a6o_report report;
 
+	report.path = NULL;
+	report.module_report = NULL;
+
 	context_status = a6o_scan_context_get(&file_context, -1, path, on_demand->scan_conf);
 
 	if (context_status == A6O_SC_MUST_SCAN)

--- a/libcore/ondemand.c
+++ b/libcore/ondemand.c
@@ -64,8 +64,6 @@ struct a6o_on_demand {
 	int last_progress_value;
 };
 
-static void process_error(const char *full_path, int entry_errno);
-
 #ifdef DEBUG
 const char *a6o_scan_conf_debug(struct a6o_scan_conf *c);
 #endif
@@ -276,21 +274,37 @@ static void fire_on_demand_completed_event(struct a6o_on_demand *on_demand)
 	a6o_event_free(ev);
 }
 
+/* this function is called when an error is found during directory traversal */
+/* or when an error occur during file scan */
+static void process_error(struct a6o_on_demand *on_demand, const char *path, int entry_errno)
+{
+	/* FIXME */
+	/* must send a detection event? */
+#if 0
+	struct a6o_report report;
+
+	a6o_report_init(&report, 42 /* scan->scan_id */, full_path, A6O_ON_DEMAND_PROGRESS_UNKNOWN);
+	a6o_log(A6O_LOG_LIB, A6O_LOG_LEVEL_WARNING, "error processing %s (error %s)", full_path, os_strerror(entry_errno));
+
+	report.status = A6O_FILE_IERROR;
+	report.module_report = os_strdup(os_strerror(entry_errno));
+
+	a6o_report_destroy(&report);
+#endif
+}
+
 static void scan_file(struct a6o_on_demand *on_demand, const char *path)
 {
 	struct a6o_scan_context file_context;
 	enum a6o_scan_context_status context_status;
 	struct a6o_report report;
 
-	report.path = NULL;
-	report.module_report = NULL;
-
-	context_status = a6o_scan_context_get(&file_context, -1, path, on_demand->scan_conf);
+	context_status = a6o_scan_context_get(&file_context, -1, path, on_demand->scan_conf, &report);
 
 	if (context_status == A6O_SC_MUST_SCAN)
 		a6o_scan_context_scan(&file_context, &report);
 	else if (context_status == A6O_SC_FILE_OPEN_ERROR)
-		process_error(path, errno);
+		process_error(on_demand, report.path, errno);
 
 	if ((report.status == A6O_FILE_MALWARE || report.status == A6O_FILE_SUSPICIOUS)
 		&& report.path != NULL)
@@ -332,24 +346,6 @@ static void scan_entry_thread_fun(gpointer data, gpointer user_data)
 #endif
 }
 
-/* this function is called when an error is found during directory traversal */
-static void process_error(const char *full_path, int entry_errno)
-{
-	/* must send a detection event? */
-	/* FIXME */
-#if 0
-	struct a6o_report report;
-
-	a6o_report_init(&report, 42 /* scan->scan_id */, full_path, A6O_ON_DEMAND_PROGRESS_UNKNOWN);
-	a6o_log(A6O_LOG_LIB, A6O_LOG_LEVEL_WARNING, "error processing %s (error %s)", full_path, os_strerror(entry_errno));
-
-	report.status = A6O_FILE_IERROR;
-	report.module_report = os_strdup(os_strerror(entry_errno));
-
-	a6o_report_destroy(&report);
-#endif
-}
-
 /* scan one entry of the directory traversal */
 /* entry can be either a directory, a file or anything else */
 /* we scan only plain files, but also signal errors */
@@ -364,7 +360,7 @@ static int scan_entry(const char *full_path, enum os_file_flag flags, int entry_
 	}
 
 	if (flags & FILE_FLAG_IS_ERROR) {
-		process_error(full_path, entry_errno);
+		process_error(on_demand, full_path, entry_errno);
 		return 1;
 	}
 


### PR DESCRIPTION
Scan daemon crashes due to uninitialized variables in function a6o_report_destroy().
You could reproduce the crash when no module is found to scan a file.

=> initialize report.path and report.module_report to NULL.

++